### PR TITLE
use exclude annotation tag in nested ToStruct call

### DIFF
--- a/dictionary.go
+++ b/dictionary.go
@@ -212,7 +212,7 @@ func (d *Dictionary) ToStruct(dest interface{}, excludeAnnotationTag string) err
 
 					obj := reflect.New(elemType)
 
-					err = d.ToStruct(obj.Interface(), "")
+					err = d.ToStruct(obj.Interface(), excludeAnnotationTag)
 					if err != nil {
 						return fmt.Errorf("slice field %q: %v", f.Name, err)
 					}

--- a/dictionary_test.go
+++ b/dictionary_test.go
@@ -105,3 +105,33 @@ func TestExcludeTag(t *testing.T) {
 		t.Errorf("mapping failed: %v", err)
 	}
 }
+
+func TestNestedExcludeTag(t *testing.T) {
+	t.Parallel()
+
+	var s struct {
+		Alpha int
+		Beta  string
+		Gamma float64 `rencode:"foo"`
+		Delta []struct {
+			Epsilon bool
+			Zeta int8 `rencode:"foo"`
+		}
+	}
+
+	var d2 Dictionary
+	d2.Add("epsilon", true)
+
+	var l List
+	l.Add(d2)
+
+	var d Dictionary
+	d.Add("alpha", int(54123))
+	d.Add("beta", "test")
+	d.Add("delta", l)
+
+	err := d.ToStruct(&s, "foo")
+	if err != nil {
+		t.Errorf("mapping failed: %v", err)
+	}
+}


### PR DESCRIPTION
Current behaviour makes it impossible to exclude fields of nested structs. This allows the exclude value to fall-through to deeper structs.