### PR TITLE
Add skippable annotation for ToStruct, add RemainingFieldsError error

### DIFF
--- a/dictionary.go
+++ b/dictionary.go
@@ -229,7 +229,7 @@ func (d *Dictionary) ToStruct(dest interface{}, excludeAnnotationTag string) err
 					err = d.ToStruct(obj.Interface(), excludeAnnotationTag)
 					if err != nil {
 						if cvtErr, ok := err.(*RemainingFieldsError); ok {
-							rf[name] = cvtErr.Fields()
+							rf[fmt.Sprintf("%s_%d", name, i)] = cvtErr.Fields()
 							err = nil
 						} else {
 							return fmt.Errorf("slice field %q: %v", f.Name, err)

--- a/dictionary_test.go
+++ b/dictionary_test.go
@@ -208,7 +208,7 @@ func TestRemainingFields(t *testing.T) {
 	if _, ok = cvtErr.Fields()["unexpected1"]; !ok {
 		t.Errorf("Error fields missing key 'unexpected1'")
 	}
-	nestedMap, ok := cvtErr.Fields()["gamma"].(map[string]interface{})
+	nestedMap, ok := cvtErr.Fields()["gamma_0"].(map[string]interface{})
 	if !ok {
 		t.Errorf("Error fields missing nested map 'gamma'")
 	}

--- a/dictionary_test.go
+++ b/dictionary_test.go
@@ -109,6 +109,31 @@ func TestExcludeTag(t *testing.T) {
 	}
 }
 
+func TestNestedStruct(t *testing.T) {
+	t.Parallel()
+
+	var s struct {
+		Alpha int
+		Beta  string
+		Gamma struct {
+			Delta bool
+		}
+	}
+
+	var d2 Dictionary
+	d2.Add("delta", true)
+
+	var d Dictionary
+	d.Add("alpha", int(54123))
+	d.Add("beta", "test")
+	d.Add("gamma", d2)
+
+	err := d.ToStruct(&s, "")
+	if err != nil {
+		t.Errorf("mapping failed: %v", err)
+	}
+}
+
 func TestNestedExcludeTag(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Two additional features for Dictionary ToStruct:

- Skippable annotation tag, for fields that may not exist in all contexts. This could be added as another function param, unsure if thats preferable.
- RemainingFieldsError error type, for missing fields context. Allows separate handling of unexpected fields or permitting unexpected fields.