### PR TITLE
Simplify exclude tag; Add more number scan;

### DIFF
--- a/dictionary.go
+++ b/dictionary.go
@@ -164,24 +164,26 @@ func (d *Dictionary) ToStruct(dest interface{}, excludeAnnotationTag string) err
 		// destination field
 		ivf := iv.Field(i)
 		name := ToSnakeCase(f.Name)
-
-		if excludeAnnotationTag != "" {
-			rencodeTag, ok := f.Tag.Lookup("rencode")
-			if ok {
+		exclude := false
+		rencodeTag, ok := f.Tag.Lookup("rencode")
+		if ok {
+			if rencodeTag == "-" {
+				exclude = true
+			} else if excludeAnnotationTag != "" {
 				tags := strings.Split(rencodeTag, ",")
-				exclude := false
 				for _, tag := range tags {
 					if tag == excludeAnnotationTag {
 						exclude = true
 						break
 					}
 				}
-				if exclude {
-					// skip this field
-					delete(tmp, name)
-					continue
-				}
 			}
+		}
+
+		if exclude {
+			// skip this field
+			delete(tmp, name)
+			continue
 		}
 
 		// see if this field is available

--- a/dictionary.go
+++ b/dictionary.go
@@ -164,9 +164,9 @@ func (d *Dictionary) ToStruct(dest interface{}, excludeAnnotationTag string) err
 		// destination field
 		ivf := iv.Field(i)
 		name := ToSnakeCase(f.Name)
-		exclude := false
-		rencodeTag, ok := f.Tag.Lookup("rencode")
-		if ok {
+
+		if rencodeTag, ok := f.Tag.Lookup("rencode"); ok {
+			exclude := false
 			if rencodeTag == "-" {
 				exclude = true
 			} else if excludeAnnotationTag != "" {
@@ -178,12 +178,11 @@ func (d *Dictionary) ToStruct(dest interface{}, excludeAnnotationTag string) err
 					}
 				}
 			}
-		}
-
-		if exclude {
-			// skip this field
-			delete(tmp, name)
-			continue
+			if exclude {
+				// skip this field
+				delete(tmp, name)
+				continue
+			}
 		}
 
 		// see if this field is available

--- a/dictionary_test.go
+++ b/dictionary_test.go
@@ -117,6 +117,7 @@ func TestNestedExcludeTag(t *testing.T) {
 			Epsilon bool
 			Zeta    int8 `rencode:"exclude-me"`
 		}
+		Omega int64 `rencode:"-"`
 	}
 
 	var d2 Dictionary

--- a/scan.go
+++ b/scan.go
@@ -155,11 +155,17 @@ func convertAssign(src, dest interface{}) error {
 		case *float32:
 			*dest = float32(src)
 			return nil
+		case *uint8:
+			*dest = uint8(src)
+			return nil
 		}
 	case int16:
 		switch dest := dest.(type) {
 		case *float32:
 			*dest = float32(src)
+			return nil
+		case *uint16:
+			*dest = uint16(src)
 			return nil
 		}
 	case int32:
@@ -167,11 +173,8 @@ func convertAssign(src, dest interface{}) error {
 		case *float32:
 			*dest = float32(src)
 			return nil
-		case *int32:
-			*dest = int32(src)
-			return nil
-		case *int16:
-			*dest = int16(src)
+		case *uint32:
+			*dest = uint32(src)
 			return nil
 		case *uint16:
 			*dest = uint16(src)

--- a/scan.go
+++ b/scan.go
@@ -110,11 +110,23 @@ func convertAssign(src, dest interface{}) error {
 		case *float64:
 			*dest = float64(src)
 			return nil
+		case *int64:
+			*dest = int64(src)
+			return nil
+		case *uint64:
+			*dest = uint64(src)
+			return nil
 		}
 	case float64:
 		switch dest := dest.(type) {
 		case *float64:
 			*dest = src
+			return nil
+		case *int64:
+			*dest = int64(src)
+			return nil
+		case *uint64:
+			*dest = uint64(src)
 			return nil
 		}
 	case []byte:
@@ -137,6 +149,9 @@ func convertAssign(src, dest interface{}) error {
 		}
 	case int8:
 		switch dest := dest.(type) {
+		case *bool:
+			*dest = src != 0
+			return nil
 		case *float32:
 			*dest = float32(src)
 			return nil
@@ -151,6 +166,15 @@ func convertAssign(src, dest interface{}) error {
 		switch dest := dest.(type) {
 		case *float32:
 			*dest = float32(src)
+			return nil
+		case *int32:
+			*dest = int32(src)
+			return nil
+		case *int16:
+			*dest = int16(src)
+			return nil
+		case *uint16:
+			*dest = uint16(src)
 			return nil
 		}
 	}


### PR DESCRIPTION
simplify tag exclude (like json "-"):
```go
	var s struct {
		Alpha int
		Beta  string
		Gamma float64 `rencode:"exclude-me"`
		Delta []struct {
			Epsilon bool
			Zeta    int8 `rencode:"exclude-me"`
		}
		Omega int64 `rencode:"-"`
	}
```

and more number scan:
* `int8` to `uint8`
* `int16` to `uint16`
* `int32` to `uint32`
* `int8` to `bool`
* `float32` and `float64` to `int64` and `uint64`

